### PR TITLE
Use clang-format-5.0 in unstable repository instead of clang-format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM debian:stretch
 
+# add unstable repositoty to install clang-format-5.0
+RUN echo -n 'deb http://ftp.debian.org/debian unstable main contrib non-free' >> /etc/apt/sources.list
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
    git curl cmake bc automake libtool build-essential pkg-config make \
    ca-certificates devscripts python unzip libllvm3.9 llvm-3.9-dev opencl-c-headers \
-   g++-6 clang-3.9 ocl-icd-opencl-dev ocl-icd-dev clang-format diffutils \
+   g++-6 clang-3.9 ocl-icd-opencl-dev ocl-icd-dev clang-format-5.0 diffutils \
  && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*


### PR DESCRIPTION
In [VC4C](https://github.com/doe300/VC4C), CI test `check-code-style` fails because the version of `clang-format` in this docker image is too old. 

I tried to use unstable repository to only install clang-format, though dependencies of other packages ware broken.